### PR TITLE
Integrate periodic table and ion activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ O portal inclui seis trilhas:
 5. soluções, acidez, água e ambiente;
 6. energia, cinética, eletroquímica e tecnologia.
 
-Também oferece um construtor de átomo, um simulador qualitativo de estados físicos, jogos de elementos e balanceamento, exercícios e uma avaliação de dez questões sorteadas. O progresso é salvo apenas no `localStorage` do navegador.
+Também oferece um construtor de átomo, um simulador qualitativo de estados físicos, um explorador dos 20 primeiros elementos, uma atividade de formação de íons, jogos de elementos e balanceamento, exercícios e uma avaliação de dez questões sorteadas. O progresso é salvo apenas no `localStorage` do navegador.
 
 ## Idiomas
 
@@ -36,6 +36,16 @@ python -m http.server 8000
 ```
 
 Depois visite `http://localhost:8000`.
+
+## Testes
+
+As regras compartilhadas de contagem de elétrons, carga iônica e configuração eletrônica podem ser verificadas com Node.js, sem instalar pacotes:
+
+```bash
+node tests/chemistry-core.test.js
+```
+
+O explorador periódico e o Átomo Arena usam um recorte introdutório dos elementos 1–20. Cargas comuns são apresentadas como tendências didáticas, não como regras universais.
 
 ## Publicar no GitHub Pages
 

--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ const elements=[
   {s:'Si',name:'Silício',clue:'Sou metaloide importante em semicondutores e apareço em silicatos.'},
   {s:'Ca',name:'Cálcio',clue:'Meu íon 2+ participa de ossos, dentes e sinalização celular.'}
 ];
+const chemistryElements=ChemistryCore.elements;
 
 const questions=[
   ['Qual propriedade relaciona massa e volume?',['Densidade','Temperatura','Pressão','Solubilidade'],0,'matéria'],
@@ -120,6 +121,30 @@ function stateFor(t){return t<=0?'sólido':t>=100?'gasoso':'líquido'}
 function drawMatter(){const t=+$('#temperature').value,state=stateFor(t),speed=state==='sólido'?.15:state==='líquido'?1.2:3; mctx.fillStyle='#071a2b';mctx.fillRect(0,0,matterCanvas.width,matterCanvas.height);particles.forEach((p,i)=>{if(state==='sólido'){const tx=55+(i%7)*68,ty=185+Math.floor(i/7)*22;p.x+=(tx-p.x)*.08+(Math.random()-.5)*speed;p.y+=(ty-p.y)*.08+(Math.random()-.5)*speed}else{p.vx+=(Math.random()-.5)*.12;p.vy+=(Math.random()-.5)*.12;const mag=Math.hypot(p.vx,p.vy)||1;p.vx=p.vx/mag*speed;p.vy=p.vy/mag*speed;p.x+=p.vx;p.y+=p.vy;if(state==='líquido')p.y+=(230-p.y)*.01;if(p.x<15||p.x>505)p.vx*=-1;if(p.y<15||p.y>315)p.vy*=-1;p.x=Math.max(15,Math.min(505,p.x));p.y=Math.max(15,Math.min(315,p.y))}mctx.fillStyle=state==='gasoso'?'#c7f464':'#69e6dc';mctx.beginPath();mctx.arc(p.x,p.y,7,0,Math.PI*2);mctx.fill()});requestAnimationFrame(drawMatter)}
 function updateMatter(){const t=+$('#temperature').value,state=stateFor(t);$('#tempLabel').textContent=`${t} °C`;$('#matterReading').textContent=`Estado predominante no modelo: ${state}. ${state==='sólido'?'Partículas vibram em posições organizadas.':state==='líquido'?'Partículas próximas mudam de posição.':'Partículas muito afastadas ocupam o recipiente.'}`}
 $('#temperature').oninput=updateMatter;updateMatter();drawMatter();
+
+const periodicGrid=$('#periodicGrid');
+periodicGrid.innerHTML=chemistryElements.map(element=>`<button type="button" data-atomic="${element.atomicNumber}" style="--group:${element.group};--period:${element.period}" aria-label="${element.name}, número atômico ${element.atomicNumber}" aria-pressed="false"><small>${element.atomicNumber}</small><b>${element.symbol}</b></button>`).join('');
+$$('[data-atomic]').forEach(button=>button.onclick=()=>{
+  const element=chemistryElements.find(item=>item.atomicNumber===+button.dataset.atomic);
+  $$('[data-atomic]').forEach(item=>item.setAttribute('aria-pressed',String(item===button)));
+  $('#periodicReading').innerHTML=`<b>${element.name} (${element.symbol})</b><br>Número atômico ${element.atomicNumber}; grupo ${element.group}; período ${element.period}; ${element.category}.<br>Configuração: ${ChemistryCore.electronConfiguration(element.atomicNumber)}.`;
+});
+
+const ionSelect=$('#ionElement');
+ionSelect.innerHTML=chemistryElements.map(element=>`<option value="${element.atomicNumber}">${element.symbol} — ${element.name}</option>`).join('');
+let selectedCharge=0;
+function updateIon(){
+  const element=chemistryElements.find(item=>item.atomicNumber===+ionSelect.value),status=$('#ionType');
+  let count;
+  try{count=ChemistryCore.electronCount(element.atomicNumber,selectedCharge)}catch(error){$('#ionReading').textContent=error.message;return}
+  const type=selectedCharge===0?'neutro':selectedCharge>0?'cátion':'ânion';
+  status.textContent=type;status.className=`status ${selectedCharge===0?'neutral':selectedCharge>0?'positive':'negative'}`;
+  const comparison=element.commonIon===null?'Este elemento forma diferentes espécies conforme o composto e as condições.':element.commonIon===selectedCharge?'Esta é uma carga monoatômica comum em contextos introdutórios.':element.commonIon===0?'Gases nobres raramente formam íons monoatômicos estáveis em condições usuais.':`Carga monoatômica comum no modelo introdutório: ${element.commonIon>0?'+':''}${element.commonIon}.`;
+  $('#ionReading').innerHTML=`<b>${ChemistryCore.ionLabel(element,selectedCharge)}</b> tem ${element.atomicNumber} prótons e ${count} elétrons.<br>Configuração: ${ChemistryCore.electronConfiguration(count)}.<br>${comparison}`;
+}
+ionSelect.onchange=updateIon;
+$$('[data-charge]').forEach(button=>button.onclick=()=>{selectedCharge=+button.dataset.charge;$$('[data-charge]').forEach(item=>item.setAttribute('aria-pressed',String(item===button)));updateIon()});
+updateIon();
 
 let currentElement;function elementRound(){currentElement=elements[Math.floor(Math.random()*elements.length)];$('#elementClue').textContent=currentElement.clue;const wrong=elements.filter(e=>e!==currentElement).sort(()=>Math.random()-.5).slice(0,3),opts=[currentElement,...wrong].sort(()=>Math.random()-.5);$('#elementOptions').innerHTML=opts.map(e=>`<button type="button" data-symbol="${e.s}">${e.s} — ${e.name}</button>`).join('');$('#elementFeedback').textContent='';$$('[data-symbol]').forEach(b=>b.onclick=()=>{const ok=b.dataset.symbol===currentElement.s;$('#elementFeedback').textContent=ok?'Correto! A pista combina com número atômico, família ou aplicação.':`Ainda não. A resposta é ${currentElement.s} — ${currentElement.name}.`;$('#elementFeedback').className=`feedback ${ok?'ok':'bad'}`})}$('#nextElement').onclick=elementRound;elementRound();
 $('#checkBalance').onclick=()=>{const [a,b,c]=['coefA','coefB','coefC'].map(id=>+$(`#${id}`).value),ok=2*a===2*c&&2*b===c;$('#balanceFeedback').textContent=ok?`Correto: ${a} H₂ + ${b} O₂ → ${c} H₂O conserva H e O.`:'Ainda não: conte separadamente H e O nos dois lados. A menor proporção inteira é 2 : 1 : 2.';$('#balanceFeedback').className=`feedback ${ok?'ok':'bad'}`};

--- a/chemistry-core.js
+++ b/chemistry-core.js
@@ -1,0 +1,36 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.ChemistryCore = api;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  const orbitals = [['1s', 2], ['2s', 2], ['2p', 6], ['3s', 2], ['3p', 6], ['4s', 2]];
+  const elements = [
+    ['H','Hidrogênio',1,1,1,'não metal',1], ['He','Hélio',2,18,1,'gás nobre',0],
+    ['Li','Lítio',3,1,2,'metal alcalino',1], ['Be','Berílio',4,2,2,'metal alcalino-terroso',2],
+    ['B','Boro',5,13,2,'metaloide',null], ['C','Carbono',6,14,2,'não metal',null],
+    ['N','Nitrogênio',7,15,2,'não metal',-3], ['O','Oxigênio',8,16,2,'não metal',-2],
+    ['F','Flúor',9,17,2,'halogênio',-1], ['Ne','Neônio',10,18,2,'gás nobre',0],
+    ['Na','Sódio',11,1,3,'metal alcalino',1], ['Mg','Magnésio',12,2,3,'metal alcalino-terroso',2],
+    ['Al','Alumínio',13,13,3,'metal',3], ['Si','Silício',14,14,3,'metaloide',null],
+    ['P','Fósforo',15,15,3,'não metal',-3], ['S','Enxofre',16,16,3,'não metal',-2],
+    ['Cl','Cloro',17,17,3,'halogênio',-1], ['Ar','Argônio',18,18,3,'gás nobre',0],
+    ['K','Potássio',19,1,4,'metal alcalino',1], ['Ca','Cálcio',20,2,4,'metal alcalino-terroso',2]
+  ].map(([symbol,name,atomicNumber,group,period,category,commonIon]) => ({symbol,name,atomicNumber,group,period,category,commonIon}));
+  function electronCount(atomicNumber, ionicCharge) {
+    const count = atomicNumber - ionicCharge;
+    if (!Number.isInteger(count) || count < 0 || count > 20) throw new RangeError('Quantidade de elétrons fora do modelo (0–20).');
+    return count;
+  }
+  function toSuperscript(value) { return String(value).replace(/[0-9+-]/g, digit => '⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻'['0123456789+-'.indexOf(digit)]); }
+  function electronConfiguration(count) {
+    let remaining = count; const filled = [];
+    for (const [orbital, capacity] of orbitals) { if (!remaining) break; const occupied = Math.min(capacity, remaining); filled.push(`${orbital}${toSuperscript(occupied)}`); remaining -= occupied; }
+    return filled.join(' ');
+  }
+  function ionLabel(element, charge) {
+    if (charge === 0) return `${element.symbol} (átomo neutro)`;
+    const magnitude = Math.abs(charge) === 1 ? '' : Math.abs(charge);
+    return `${element.symbol}${toSuperscript(`${magnitude}${charge > 0 ? '+' : '-'}`)}`;
+  }
+  return {elements, electronCount, electronConfiguration, ionLabel};
+}));

--- a/index.html
+++ b/index.html
@@ -125,6 +125,23 @@
           <p id="matterReading" class="reading"></p>
           <p class="model-note">Modelo qualitativo em pressão atmosférica aproximada; não representa escala, forma ou velocidade molecular real.</p>
         </article>
+        <article class="lab-card periodic-lab">
+          <div class="card-title"><div><span class="tag">SIMULADOR 03</span><h3>Explorador periódico</h3></div><span class="status">20 elementos</span></div>
+          <p>Selecione um elemento para relacionar posição, categoria e distribuição eletrônica.</p>
+          <div id="periodicGrid" class="periodic-grid" aria-label="Tabela periódica simplificada dos primeiros 20 elementos"></div>
+          <div id="periodicReading" class="reading panel-reading" aria-live="polite">Escolha um elemento.</div>
+          <p class="model-note">Recorte introdutório dos elementos 1–20. Propriedades e classificações podem exigir contexto e fonte específica.</p>
+        </article>
+        <article class="lab-card ion-lab">
+          <div class="card-title"><div><span class="tag">SIMULADOR 04</span><h3>Átomo Arena: íons</h3></div><span id="ionType" class="status neutral">neutro</span></div>
+          <label for="ionElement">Elemento</label>
+          <select id="ionElement" class="wide-select"></select>
+          <fieldset class="charge-picker"><legend>Escolha a carga do íon</legend>
+            <button type="button" data-charge="2">+2</button><button type="button" data-charge="1">+1</button><button type="button" data-charge="0">0</button><button type="button" data-charge="-1">−1</button><button type="button" data-charge="-2">−2</button>
+          </fieldset>
+          <div id="ionReading" class="reading panel-reading" aria-live="polite"></div>
+          <p class="model-note">Carga positiva significa perda de elétrons; carga negativa significa ganho. O íon mais comum é uma tendência didática, não uma regra universal.</p>
+        </article>
       </div>
     </section>
 
@@ -209,6 +226,7 @@
   </main>
 
   <footer><div class="brand"><span class="brand-mark">C</span><span>Chemical</span></div><p>Idealizado por <a href="#quem-sou">Sidiney Rodrigues</a>, com desenvolvimento assistido por <a href="https://developers.openai.com/codex/" target="_blank" rel="noopener noreferrer">OpenAI Codex</a>.</p><p>Conteúdo educacional. Experimentos reais exigem professor, infraestrutura e protocolo de segurança.</p></footer>
+  <script src="chemistry-core.js"></script>
   <script src="app.js"></script>
   <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit" async></script>
 </body>

--- a/tests/chemistry-core.test.js
+++ b/tests/chemistry-core.test.js
@@ -1,0 +1,14 @@
+const assert = require('node:assert/strict');
+const {elements, electronCount, electronConfiguration, ionLabel} = require('../chemistry-core.js');
+const bySymbol = symbol => elements.find(element => element.symbol === symbol);
+
+assert.equal(elements.length, 20);
+assert.equal(electronCount(11, 1), 10, 'Na+ deve ter 10 elétrons');
+assert.equal(electronCount(12, 2), 10, 'Mg2+ deve ter 10 elétrons');
+assert.equal(electronCount(17, -1), 18, 'Cl- deve ter 18 elétrons');
+assert.equal(electronCount(8, -2), 10, 'O2- deve ter 10 elétrons');
+assert.equal(electronConfiguration(10), '1s² 2s² 2p⁶');
+assert.equal(electronConfiguration(20), '1s² 2s² 2p⁶ 3s² 3p⁶ 4s²');
+assert.equal(ionLabel(bySymbol('Mg'), 2), 'Mg²⁺');
+assert.throws(() => electronCount(1, 2), RangeError);
+console.log('chemistry-core: 8 verificações aprovadas');

--- a/ux-fixes.css
+++ b/ux-fixes.css
@@ -120,3 +120,21 @@ footer a { color: var(--lime); }
   .about-copy { font-size: 1.04rem; }
   .project-credits { grid-template-columns: 1fr; }
 }
+
+/* Explorador periódico e formação de íons */
+.periodic-grid { display: grid; grid-template-columns: repeat(18,minmax(32px,1fr)); gap: 4px; margin: 1rem 0; overflow-x: auto; padding-bottom: .4rem; }
+.periodic-grid button { grid-column: var(--group); grid-row: var(--period); min-width: 38px; min-height: 52px; padding: .25rem; border: 1px solid var(--line); border-radius: 8px; background: #eef3ef; color: var(--ink); cursor: pointer; }
+.periodic-grid button:hover,.periodic-grid button[aria-pressed="true"] { border-color: var(--blue); background: #dfe9ff; box-shadow: inset 0 0 0 1px var(--blue); }
+.periodic-grid small,.periodic-grid b { display: block; line-height: 1.1; }
+.periodic-grid small { font-size: .58rem; color: var(--muted); }
+.periodic-grid b { margin-top: .2rem; font-size: .95rem; }
+.panel-reading { min-height: 92px; padding: 1rem; border-left: 4px solid var(--aqua); border-radius: 10px; background: #eef3ef; }
+.wide-select { display: block; width: 100%; min-height: 48px; margin: .4rem 0 1rem; padding: .6rem .75rem; border: 1px solid var(--line); border-radius: 10px; background: var(--white); color: var(--ink); font-weight: 750; }
+.charge-picker { margin: 0 0 1rem; padding: 0; border: 0; }
+.charge-picker legend { margin-bottom: .5rem; font-size: .78rem; font-weight: 800; }
+.charge-picker button { min-width: 52px; min-height: 44px; margin: 0 .3rem .4rem 0; border: 1px solid var(--line); border-radius: 10px; background: var(--white); cursor: pointer; font-weight: 850; }
+.charge-picker button:hover,.charge-picker button[aria-pressed="true"] { background: var(--ink); color: var(--white); border-color: var(--ink); }
+
+@media (max-width: 600px) {
+  .periodic-grid { grid-template-columns: repeat(18,38px); }
+}


### PR DESCRIPTION
Substitui os protótipos desktop das PRs #1 e #2 por atividades integradas ao portal web atual.

- adiciona explorador responsivo dos elementos 1–20;
- adiciona Átomo Arena para formação de íons;
- corrige a convenção: elétrons = número atômico − carga;
- distingue cátion, ânion e átomo neutro;
- evita tratar cargas comuns como regras universais;
- centraliza dados e cálculos em `chemistry-core.js`;
- adiciona testes para Na⁺, Mg²⁺, Cl⁻, O²⁻ e configurações eletrônicas.

Verificação executada: `node tests/chemistry-core.test.js`, `node --check` e `git diff --check`.

Substitui #1 e #2 após revisão.